### PR TITLE
fix missing Stream inheritance

### DIFF
--- a/components/obis/obis.h
+++ b/components/obis/obis.h
@@ -62,9 +62,10 @@ class OBISComponent : public Component, public uart::UARTDevice {
  protected:
   std::map<std::string, sensor::Sensor *> channels_;
   void handle_line(char *line);
+  char buf[OBIS_BUFSIZE];
+  size_t index{0};
 
  public:
-  void setup() override;
   void loop() override;
   void register_channel(OBISChannel *channel) { this->channels_[channel->channel_] = channel; }
 };


### PR DESCRIPTION
The UARTDevice no longer inherits from Stream, thus setTimeout and readBytesUntil are not available.

Timeout seems to be 100ms in any case, thus should not be required anymore (https://github.com/esphome/esphome/blob/dev/esphome/components/uart/uart_component.cpp#L14).

I reimplemented the reading using read_bytes directly.